### PR TITLE
use dnsimple account id instead of addon id

### DIFF
--- a/web/gateways/dnsimple.ex
+++ b/web/gateways/dnsimple.ex
@@ -18,7 +18,7 @@ defmodule HelloDomains.Dnsimple do
   # Domains
 
   def domains(account) do
-    domain_service.all_domains(client(account), account.id)
+    domain_service.all_domains(client(account), account.dnsimple_account_id)
   end
 
   # Client for account


### PR DESCRIPTION
Sending the add-on account id leads to a `HTTP 401` from the DNSimple API