### PR TITLE
Add support for base_url configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ use Mix.Config
 
 config :hello_domains,
   dnsimple_client_id: "client_id",
-  dnsimple_client_secret: "client_secret",
-  dnsimple_client_base_url: "https://api.sandbox.dnsimple.com
+  dnsimple_client_secret: "client_secret"
 ```
 
 ## Start the Hello Domains app

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ use Mix.Config
 
 config :hello_domains,
   dnsimple_client_id: "client_id",
-  dnsimple_client_secret: "client_secret"
+  dnsimple_client_secret: "client_secret",
+  dnsimple_client_base_url: "https://api.sandbox.dnsimple.com
 ```
 
 ## Start the Hello Domains app

--- a/config/config.exs
+++ b/config/config.exs
@@ -22,6 +22,10 @@ config :logger, :console,
   format: "$time $metadata[$level] $message\n",
   metadata: [:request_id]
 
+# Configures the DNSimple environment to target
+config :hello_domains,
+  dnsimple_client_base_url: "https://api.sandbox.dnsimple.com"
+
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{Mix.env}.exs"

--- a/config/test.exs
+++ b/config/test.exs
@@ -21,7 +21,7 @@ config :hello_domains, HelloDomains.Repo,
 config :hello_domains,
   dnsimple_client_id: "dnsimple-client-id",
   dnsimple_client_secret: "dnsimple-client-secret",
-  dnsimple_client_base_url: "https://api.test.dnsimple.com",
+  dnsimple_client_base_url: "https://api.dnsimple.com",
   dnsimple_oauth_service: HelloDomains.Dnsimple.OauthMock,
   dnsimple_identity_service: HelloDomains.Dnsimple.IdentityMock,
   dnsimple_domains_service: HelloDomains.Dnsimple.DomainsMock

--- a/config/test.exs
+++ b/config/test.exs
@@ -21,6 +21,7 @@ config :hello_domains, HelloDomains.Repo,
 config :hello_domains,
   dnsimple_client_id: "dnsimple-client-id",
   dnsimple_client_secret: "dnsimple-client-secret",
+  dnsimple_client_base_url: "https://api.test.dnsimple.com",
   dnsimple_oauth_service: HelloDomains.Dnsimple.OauthMock,
   dnsimple_identity_service: HelloDomains.Dnsimple.IdentityMock,
   dnsimple_domains_service: HelloDomains.Dnsimple.DomainsMock

--- a/test/support/dnsimple_mock.ex
+++ b/test/support/dnsimple_mock.ex
@@ -5,8 +5,8 @@ defmodule HelloDomains.Dnsimple.OauthMock do
 end
 
 defmodule HelloDomains.Dnsimple.IdentityMock do
-  def whoami(_client) do
-    {:ok, %Dnsimple.Response{data: %{account: %{"id" => 1}}}}
+  def whoami(_access_token) do
+    {:ok, %Dnsimple.Response{data: %{account: %{id: 1, email: "email@example.com"}}}}
   end
 end
 
@@ -16,7 +16,7 @@ defmodule HelloDomains.Dnsimple.DomainsMock do
   end
 
   def all_domains(_client, _account_id) do
-    []
+    {:ok, []}
   end
 
   def domain(_client, _account_id, name) do

--- a/test/support/dnsimple_mock.ex
+++ b/test/support/dnsimple_mock.ex
@@ -5,7 +5,7 @@ defmodule HelloDomains.Dnsimple.OauthMock do
 end
 
 defmodule HelloDomains.Dnsimple.IdentityMock do
-  def whoami(_access_token) do
+  def whoami(_client) do
     {:ok, %Dnsimple.Response{data: %{account: %{id: 1, email: "email@example.com"}}}}
   end
 end

--- a/test/support/dnsimple_mock.ex
+++ b/test/support/dnsimple_mock.ex
@@ -11,15 +11,7 @@ defmodule HelloDomains.Dnsimple.IdentityMock do
 end
 
 defmodule HelloDomains.Dnsimple.DomainsMock do
-  def domains(_client, _account_id, _opts) do
-    {:ok, %Dnsimple.Response{data: []}}
-  end
-
   def all_domains(_client, _account_id) do
     {:ok, []}
-  end
-
-  def domain(_client, _account_id, name) do
-    {:ok, %Dnsimple.Response{data: %Dnsimple.Domain{name: name}}}
   end
 end

--- a/web/controllers/dnsimple_oauth_controller.ex
+++ b/web/controllers/dnsimple_oauth_controller.ex
@@ -5,11 +5,10 @@ defmodule HelloDomains.DnsimpleOauthController do
 
   def new(conn, _params) do
     client    = %Dnsimple.Client{}
-    client_id = Application.fetch_env!(:hello_domains, :dnsimple_client_id)
     state = :crypto.strong_rand_bytes(8) |> Base.url_encode64 |> binary_part(0, 8)
     assign(conn, :dnsimple_oauth_state, state)
     conn = put_session(conn, :dnsimple_oauth_state, state)
-    oauth_url = HelloDomains.Dnsimple.authorize_url(client, client_id, state: state)
+    oauth_url = HelloDomains.Dnsimple.authorize_url(client, state: state)
     redirect(conn, external: oauth_url)
   end
 
@@ -21,8 +20,6 @@ defmodule HelloDomains.DnsimpleOauthController do
 
     client = %Dnsimple.Client{}
     attributes = %{
-      client_id: Application.fetch_env!(:hello_domains, :dnsimple_client_id),
-      client_secret: Application.fetch_env!(:hello_domains, :dnsimple_client_secret),
       code: params["code"],
       state: params["state"]
     }

--- a/web/controllers/dnsimple_oauth_controller.ex
+++ b/web/controllers/dnsimple_oauth_controller.ex
@@ -17,11 +17,7 @@ defmodule HelloDomains.DnsimpleOauthController do
       raise "State does not match"
     end
 
-    client = %Dnsimple.Client{}
-    attributes = %{
-      code: params["code"],
-      state: params["state"]
-    }
+    attributes = %{code: params["code"], state: params["state"]}
     case HelloDomains.Dnsimple.exchange_authorization_for_token(attributes) do
       {:ok, response} ->
         access_token = response.data.access_token
@@ -46,4 +42,3 @@ defmodule HelloDomains.DnsimpleOauthController do
   end
 
 end
-

--- a/web/controllers/page_controller.ex
+++ b/web/controllers/page_controller.ex
@@ -5,6 +5,13 @@ defmodule HelloDomains.PageController do
 
   def index(conn, _params) do
     account = conn.assigns[:current_account]
-    render conn, "index.html", dnsimple_domains: HelloDomains.Dnsimple.domains(account)
+
+    case HelloDomains.Dnsimple.domains(account) do
+      {:ok, domains} ->
+        render conn, "index.html", dnsimple_domains: domains
+      {:error, error} ->
+        IO.inspect(error)
+        raise "Failed to retreive account domains: #{inspect error}"
+    end
   end
 end

--- a/web/gateways/dnsimple.ex
+++ b/web/gateways/dnsimple.ex
@@ -6,11 +6,12 @@ defmodule HelloDomains.Dnsimple do
 
   # OAuth
 
-  def authorize_url(client, client_id, options) do
-    Dnsimple.Oauth.authorize_url(client, client_id, state: options[:state])
+  def authorize_url(client, options) do
+    Dnsimple.Oauth.authorize_url(client, @client_id, state: options[:state])
   end
 
   def exchange_authorization_for_token(client, attributes) do
+    attributes = Map.merge(attributes, %{client_id: @client_id, client_secret: @client_secret})
     oauth_service.exchange_authorization_for_token(client, attributes)
   end
 

--- a/web/gateways/dnsimple.ex
+++ b/web/gateways/dnsimple.ex
@@ -1,17 +1,13 @@
 defmodule HelloDomains.Dnsimple do
 
-  @base_url Application.fetch_env!(:hello_domains, :dnsimple_client_base_url)
-  @client_id Application.fetch_env!(:hello_domains, :dnsimple_client_id)
-  @client_secret Application.fetch_env!(:hello_domains, :dnsimple_client_secret)
-
   # OAuth
 
   def authorize_url(options) do
-    Dnsimple.Oauth.authorize_url(client, @client_id, state: options[:state])
+    Dnsimple.Oauth.authorize_url(client, client_id, state: options[:state])
   end
 
   def exchange_authorization_for_token(attributes) do
-    attributes = Map.merge(attributes, %{client_id: @client_id, client_secret: @client_secret})
+    attributes = Map.merge(attributes, %{client_id: client_id, client_secret: client_secret})
     oauth_service.exchange_authorization_for_token(client, attributes)
   end
 
@@ -30,13 +26,13 @@ defmodule HelloDomains.Dnsimple do
   # Client
 
   def client do
-    %Dnsimple.Client{base_url: @base_url}
+    %Dnsimple.Client{base_url: base_url}
   end
   def client(%HelloDomains.Account{dnsimple_access_token: access_token}) do
     client(access_token)
   end
   def client(access_token) do
-    %Dnsimple.Client{base_url: @base_url, access_token: access_token}
+    %Dnsimple.Client{base_url: base_url, access_token: access_token}
   end
 
   # Service modules
@@ -52,4 +48,11 @@ defmodule HelloDomains.Dnsimple do
   defp domain_service do
     Application.get_env(:hello_domains, :dnsimple_domains_service, Dnsimple.Domains)
   end
+
+  # Configuration
+
+  def base_url,      do: Application.fetch_env!(:hello_domains, :dnsimple_client_base_url)
+  def client_id,     do: Application.fetch_env!(:hello_domains, :dnsimple_client_id)
+  def client_secret, do: Application.fetch_env!(:hello_domains, :dnsimple_client_secret)
+
 end

--- a/web/gateways/dnsimple.ex
+++ b/web/gateways/dnsimple.ex
@@ -1,4 +1,9 @@
 defmodule HelloDomains.Dnsimple do
+
+  @base_url Application.fetch_env!(:hello_domains, :dnsimple_client_base_url)
+  @client_id Application.fetch_env!(:hello_domains, :dnsimple_client_id)
+  @client_secret Application.fetch_env!(:hello_domains, :dnsimple_client_secret)
+
   # OAuth
 
   def authorize_url(client, client_id, options) do

--- a/web/gateways/dnsimple.ex
+++ b/web/gateways/dnsimple.ex
@@ -6,19 +6,19 @@ defmodule HelloDomains.Dnsimple do
 
   # OAuth
 
-  def authorize_url(client, options) do
+  def authorize_url(options) do
     Dnsimple.Oauth.authorize_url(client, @client_id, state: options[:state])
   end
 
-  def exchange_authorization_for_token(client, attributes) do
+  def exchange_authorization_for_token(attributes) do
     attributes = Map.merge(attributes, %{client_id: @client_id, client_secret: @client_secret})
     oauth_service.exchange_authorization_for_token(client, attributes)
   end
 
   # Identity
 
-  def whoami(client) do
-    identity_service.whoami(client)
+  def whoami(access_token) do
+    identity_service.whoami(client(access_token))
   end
 
   # Domains
@@ -27,10 +27,16 @@ defmodule HelloDomains.Dnsimple do
     domain_service.all_domains(client(account), account.dnsimple_account_id)
   end
 
-  # Client for account
+  # Client
 
-  def client(account) do
-    %Dnsimple.Client{access_token: account.dnsimple_access_token}
+  def client do
+    %Dnsimple.Client{base_url: @base_url}
+  end
+  def client(%HelloDomains.Account{dnsimple_access_token: access_token}) do
+    client(access_token)
+  end
+  def client(access_token) do
+    %Dnsimple.Client{base_url: @base_url, access_token: access_token}
   end
 
   # Service modules


### PR DESCRIPTION
This PR does two things:

- Adds the option to configure `base_url` as part of the DNSimple client configuration. This is required to be able to point the HelloDomains app to production and sandbox.

  In order to be able to do this I had to refactor some code to push the client creation to the `Dnsimple` gateway (it was spread in several places).

- Updates the code base with changes that should have happened in the context of #3. Didn't do them there because I wanted to make sure things worked in the context of this PR.

  There is still a deprecation warning to be fixed introduced by upgrading Ecto to the latest version, but we can fix that eventually.